### PR TITLE
Corrigindo acentuação do Amapá + dados do dia 28/03/2020

### DIFF
--- a/data/2020-03-10.csv
+++ b/data/2020-03-10.csv
@@ -4,7 +4,7 @@ https://g1.globo.com/bemestar/coronavirus/noticia/2020/03/10/brasil-tem-34-casos
 Estado,Suspeitos,Confirmados
 Acre (AC),3,0
 Alagoas (AL),6,1
-Amapa (AP),0,0
+Amapá (AP),0,0
 Amazonas (AM),3,0
 Bahia (BA),46,2
 Ceará (CE),22,0

--- a/data/2020-03-11.csv
+++ b/data/2020-03-11.csv
@@ -4,7 +4,7 @@ https://g1.globo.com/bemestar/coronavirus/noticia/2020/03/11/brasil-tem-52-casos
 Estado,Suspeitos,Confirmados
 Acre (AC),3,0
 Alagoas (AL),4,1
-Amapa (AP),0,0
+Amapá (AP),0,0
 Amazonas (AM),1,0
 Bahia (BA),65,2
 Ceará (CE),22,0

--- a/data/2020-03-12.csv
+++ b/data/2020-03-12.csv
@@ -4,7 +4,7 @@ https://g1.globo.com/bemestar/coronavirus/noticia/2020/03/12/brasil-tem-76-casos
 Estado,Suspeitos,Confirmados
 Acre (AC),3,0
 Alagoas (AL),6,1
-Amapa (AP),0,0
+Amapá (AP),0,0
 Amazonas (AM),1,0
 Bahia (BA),65,2
 Ceará (CE),22,0

--- a/data/2020-03-14.csv
+++ b/data/2020-03-14.csv
@@ -4,7 +4,7 @@ https://g1.globo.com/bemestar/coronavirus/noticia/2020/03/14/brasil-tem-121-caso
 Estado,Suspeitos,Confirmados
 Acre (AC),3,0
 Alagoas (AL),6,1
-Amapa (AP),0,0
+Amapá (AP),0,0
 Amazonas (AM),1,0
 Bahia (BA),65,2
 Ceará (CE),22,0

--- a/data/2020-03-28.csv
+++ b/data/2020-03-28.csv
@@ -1,4 +1,4 @@
-https://g1.globo.com/bemestar/coronavirus/noticia/2020/03/28/casos-de-coronavirus-no-brasil-em-28-de-marco.ghtml,,
+https://www.saude.gov.br/noticias/agencia-saude/46618-brasil-registra-3-904-casos-confirmados-de-coronavirus-e-111-mortes,,
 ,,
 ,,
 Estado,Secretarias,Ministério

--- a/data/2020-03-28.csv
+++ b/data/2020-03-28.csv
@@ -3,30 +3,30 @@ https://g1.globo.com/bemestar/coronavirus/noticia/2020/03/28/casos-de-coronaviru
 ,,
 Estado,Secretarias,Ministério
 Acre (AC),25,25
-Alagoas (AL),14,
-Amapá (AP),4,
-Amazonas (AM),111,
-Bahia (BA),128,
-Ceará (CE),314,
-Distrito Federal(DF),260,
-Espírito Santo (ES),53,
-Goiás (GO),56,
-Maranhão (MA),14,
-Mato Grosso (MT),13,
-Mato Grosso do Sul (MS),31,
-Minas Gerais (MG),205,
-Pará (PA),17,
-Paraíba (PB),14,
-Paraná (PR),133,
-Pernambuco (PE),68,
-Piauí (PI),11,
-Rio de Janeiro (RJ),558,
-Rio Grande do Norte (RN),45,
-Rio Grande do Sul (RS),197,
-Rondônia (RO),6,
-Roraima (RR),12,
-Santa Catarina (SC),184,
-São Paulo (SP),1406,
-Sergipe (SE),16,
-Tocantins (TO),9,
-TOTAL,3904,25
+Alagoas (AL),14,14
+Amapá (AP),4,4
+Amazonas (AM),111,111
+Bahia (BA),128,128
+Ceará (CE),314,314
+Distrito Federal(DF),260,260
+Espírito Santo (ES),53,53
+Goiás (GO),56,56
+Maranhão (MA),14,14
+Mato Grosso (MT),13,13
+Mato Grosso do Sul (MS),31,31
+Minas Gerais (MG),205,205
+Pará (PA),17,17
+Paraíba (PB),14,14
+Paraná (PR),133,133
+Pernambuco (PE),68,68
+Piauí (PI),11,11
+Rio de Janeiro (RJ),558,558
+Rio Grande do Norte (RN),45,45
+Rio Grande do Sul (RS),197,197
+Rondônia (RO),6,6
+Roraima (RR),12,12
+Santa Catarina (SC),184,184
+São Paulo (SP),1406,1406
+Sergipe (SE),16,16
+Tocantins (TO),9,9
+TOTAL,3904,3904


### PR DESCRIPTION
Fonte para dados do ministério no dia 28/03/2020: https://www.saude.gov.br/noticias/agencia-saude/46618-brasil-registra-3-904-casos-confirmados-de-coronavirus-e-111-mortes